### PR TITLE
#4 default value error

### DIFF
--- a/dookug-document/dookug-document-service/src/main/java/hu/icellmobilsoft/dookug/document/service/cache/TemplateCache.java
+++ b/dookug-document/dookug-document-service/src/main/java/hu/icellmobilsoft/dookug/document/service/cache/TemplateCache.java
@@ -53,7 +53,7 @@ public class TemplateCache extends AbstractCache<String, TemplateCacheItem> {
     @Inject
     @ConfigProperty(name = ConfigKeys.Cache.DOOKUG_SERVICE_CACHE_TEMPLATE_TTL,
             defaultValue = ConfigKeys.Cache.DEFAULT_DOOKUG_SERVICE_CACHE_TEMPLATE_TTL_IN_MINUTES)
-    private Integer cacheTTLInMinutes;
+    private int cacheTTLInMinutes;
 
     /**
      * Add a new {@link TemplateCacheItem} to the Map


### PR DESCRIPTION
null került bele a cacheTTLInMinutes-be, ha nem volt megadva érték. 