### PR TITLE
Precompiled template caching

### DIFF
--- a/docs/release-notes/v1.0.0.adoc
+++ b/docs/release-notes/v1.0.0.adoc
@@ -7,3 +7,4 @@
 * gitHub Workflows - java 17 upgrade
 * Bugfix: The `not` helper function has been fixed, it evaluated the `false` parameter incorrectly.
 * Handlebars version bump: 4.3.1 -> 4.4.0
+* Handlebars caching: Handlebars template engine now uses its in-built caching mechanism for compiled templates

--- a/dookug-engine/dookug-engine-handlebars/src/main/java/hu/icellmobilsoft/dookug/engine/handlebars/HandlebarsTemplateCompiler.java
+++ b/dookug-engine/dookug-engine-handlebars/src/main/java/hu/icellmobilsoft/dookug/engine/handlebars/HandlebarsTemplateCompiler.java
@@ -37,6 +37,7 @@ import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.cache.ConcurrentMapTemplateCache;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
@@ -156,7 +157,7 @@ public class HandlebarsTemplateCompiler implements ITemplateCompiler {
     @PostConstruct
     public void init() throws BaseException {
         EscapingStrategy escapingStrategy = escapingStrategyFactory.createEscapingStrategy(strategyKeyOptional);
-        handlebars = new Handlebars(templateLoader).with(escapingStrategy);
+        handlebars = new Handlebars(templateLoader).with(escapingStrategy).with(new ConcurrentMapTemplateCache().setReload(true));
         helperRegister.findAndRegisterHelpers(handlebars);
     }
 


### PR DESCRIPTION
Before:
```
2024-06-04 06:46:38.866 DEBUG [thread:default task-1] [hu.icellmobilsoft.dookug.engine.handlebars.HandlebarsTemplateCompiler] [sid:4LLRKVM7KXZRHCEB] [k8s_namespace:] - Handlebars starting compile [1] templates, main template name [PROJECT_INVOICE_TEMPLATE_FULL]...
2024-06-04T06:46:38.873648619Z 2024-06-04 06:46:38.873 DEBUG [thread:default task-1] [hu.icellmobilsoft.dookug.engine.handlebars.HandlebarsTemplateCompiler] [sid:4LLRKVM7KXZRHCEB] [k8s_namespace:] - ...Handlebars compile done.
```

After:
```
2024-06-04 06:44:49.510 DEBUG [thread:default task-1] [hu.icellmobilsoft.dookug.engine.handlebars.HandlebarsTemplateCompiler] [sid:4LLRIJ8JPG7UOWMT] [k8s_namespace:] - Handlebars starting compile [1] templates, main template name [PROJECT_INVOICE_TEMPLATE_FULL]...
2024-06-04T06:44:49.512235055Z 2024-06-04 06:44:49.512 DEBUG [thread:default task-1] [com.github.jknack.handlebars.cache.ConcurrentMapTemplateCache] [sid:4LLRIJ8JPG7UOWMT] [k8s_namespace:] - Found in cache: PROJECT_INVOICE_TEMPLATE_FULL
2024-06-04T06:44:49.512246476Z 2024-06-04 06:44:49.512 DEBUG [thread:default task-1] [hu.icellmobilsoft.dookug.engine.handlebars.HandlebarsTemplateCompiler] [sid:4LLRIJ8JPG7UOWMT] [k8s_namespace:] - ...Handlebars compile done.
```